### PR TITLE
Fix command name from getCmdBuf to getCommandBuf

### DIFF
--- a/ROM_Class_GBA.sbp
+++ b/ROM_Class_GBA.sbp
@@ -134,7 +134,7 @@ Public
 
 			'コマンドをキャッシュする
 			cacheBufUsage=ft->getBufUsage()-bufStart
-			memcpy(cacheBuf,ft->getCmdBuf()+bufStart,cacheBufUsage)
+			memcpy(cacheBuf,ft->getCommandBuf()+bufStart,cacheBufUsage)
 			cacheARR_Len=length
 			'cacheMiss++
 			'printf(ex"\n\ncache miss:%d, len=%d    \n\n",cacheMiss,length)


### PR DESCRIPTION
最新のAB-FT232HLibライブラリとコマンド名が異なっていたので、最新のコマンドに修正しました。

Follow change b783dad at AB-FT232HLib repository